### PR TITLE
Fix CI workflow to compile assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
           bundle install
           npm install
           npx @tailwindcss/cli -i ./config/tailwind.css -o ./app/assets/css/tailwind.css
+          bundle exec hanami assets compile
 
       - name: Set up database
         run: bundle exec hanami db prepare


### PR DESCRIPTION
## Summary

This updates the CI workflow to include the `hanami assets compile` step, ensuring assets are compiled during CI runs to prevent issues with missing or outdated assets in the build process.

## Type of Change

<!-- Mark with an `x` all that apply -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code cleanup or refactoring
- [x] 🔧 Build system or dependency changes
- [ ] 🧪 Test improvements

## What Changed?

The CI configuration now includes the step `hanami assets compile`, which compiles assets during CI runs to prevent build-time failures due to missing or outdated assets.

## Why?

Without this step, CI runs may encounter issues when assets are not precompiled, leading to build errors. Adding this step ensures comprehensive build validation.

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Existing tests pass (`mise test`)
- [ ] New tests added for new functionality
- [ ] Manual testing performed
- [ ] Code follows style guidelines (`mise lint`)