### PR TITLE
Fix "Remember me" functionality in sign-in flow

### DIFF
--- a/app/actions/sessions/create.rb
+++ b/app/actions/sessions/create.rb
@@ -24,7 +24,7 @@ module Pennywise
         private
 
         def handle_successful_authentication(identity, request, response)
-          case create_session.call(identity, request, remember: request.params[:remember])
+          case create_session.call(identity, request, remember: request.params.dig(:session, :remember))
           in Success[token]
             response.session[:token] = token
             response.flash.next[:success] = "Welcome back!"


### PR DESCRIPTION
## Summary

This fixes a bug in the "Remember me" functionality during user sign-in.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code cleanup or refactoring
- [ ] 🔧 Build system or dependency changes
- [ ] 🧪 Test improvements

## What Changed?

The `remember` parameter from the sign-in form is now correctly passed to the session creation operation, enabling extended session durations when requested.

## Why?

This fix ensures that the "Remember me" option during sign-in works as expected, providing users with the intended functionality of an extended session.

## How Has This Been Tested?

- [x] Existing tests pass (`mise test`)
- [ ] New tests added for new functionality
- [x] Manual testing performed
- [x] Code follows style guidelines (`mise lint`)